### PR TITLE
feat: add pow_up and pow_down

### DIFF
--- a/Move.toml
+++ b/Move.toml
@@ -3,7 +3,7 @@ name = "FixedPoint64"
 version = "0.1.0"
 
 [addresses]
-fixed_point64 = "92285e3fb7903c2b2fd17d96da946cbd76b927a1bad1649f465b698af5f76e87"
+fixed_point64 = "72f8c365793d14b86a50bbcbdf81cdcc7b3ef94604376a777a7018c14279231a"
 
 [dev-dependencies.MoveStdlib]
 git = "https://github.com/aptos-labs/aptos-core.git"

--- a/sources/fixed_point64.move
+++ b/sources/fixed_point64.move
@@ -82,7 +82,7 @@ module fixed_point64::fixed_point64 {
 
     /// Get integer "one" in FixedPoint64
     public fun one(): FixedPoint64 {
-        FixedPoint64{ v: 1 << 64 }
+        FixedPoint64{ v: TWO_POW_64 }
     }
     
     /// Get integer "zero" in FixedPoint64

--- a/sources/log_exp_math.move
+++ b/sources/log_exp_math.move
@@ -31,6 +31,8 @@ module fixed_point64::log_exp_math {
 
     const LOG_2_E_INV_RAW: u128 = 12786308645977587712; // 1.0 / log_2(e)
 
+    const TEN_EXP_MINUS_9: u128 = 18446744073; // fixed_point64::fraction(1, 1000000000)
+
     const PRECISION: u8 = 64; // number of bits in the mantissa
 
     // code reference: https://github.com/dmoulding/log2fix/blob/master/log2fix.c
@@ -176,18 +178,70 @@ module fixed_point64::log_exp_math {
     }
 
     public fun pow(x: FixedPoint64, y: FixedPoint64): FixedPoint64 {
-        let result;
-        if (fixed_point64::to_u128(y) == 0) {
-            // We solve the 0^0 indetermination by making it equal to one.
-            result = fixed_point64::one();
-        } else if (fixed_point64::to_u128(x) == 0) {
-            result = fixed_point64::zero();
+        let (success, result) = try_simple_pow(x, y);
+        if (success) {
+            result
         } else {
             // x^y = exp(y * ln(x))
             let (sign, ln_x) = ln(x);
             let y_times_ln_x = fixed_point64::mul_fp(y, ln_x);
-            result = exp(sign, y_times_ln_x);
-        };
-        result
+            exp(sign, y_times_ln_x)
+        }
+    }
+    
+    /// pow_up adds 10^-9 to the result of pow if Taylor series is used
+    /// so that the result is always greater than or equal to the true value
+    public fun pow_up(x: FixedPoint64, y: FixedPoint64): FixedPoint64 {
+        let (success, result) = try_simple_pow(x, y);
+        if (success) {
+            result
+        } else {
+            // x^y = exp(y * ln(x))
+            let (sign, ln_x) = ln(x);
+            let y_times_ln_x = fixed_point64::mul_fp(y, ln_x);
+            fixed_point64::add_fp(exp(sign, y_times_ln_x), fixed_point64::from_u128(TEN_EXP_MINUS_9))
+        }
+    }
+    
+    /// pow_down substracts 10^-9 from the result of pow if Taylor series is used and the result is greater than 10^-9
+    /// so that the result is always smaller than or equal to the true value
+    public fun pow_down(x: FixedPoint64, y: FixedPoint64): FixedPoint64 {
+        let (success, result) = try_simple_pow(x, y);
+        if (success) {
+            result
+        } else {
+            // x^y = exp(y * ln(x))
+            let (sign, ln_x) = ln(x);
+            let y_times_ln_x = fixed_point64::mul_fp(y, ln_x);
+            let result = exp(sign, y_times_ln_x);
+            let epsilon = fixed_point64::from_u128(TEN_EXP_MINUS_9);
+            if (fixed_point64::gt(&result, &epsilon)) {
+                fixed_point64::sub_fp(result, epsilon)
+            } else {
+                fixed_point64::zero()
+            }
+        }
+    }
+
+    /// try_simple_pow returns the result of pow if it can be computed using simple rules
+    /// e.g. x^0 = 1, x^1 = x, x^2 = x * x, x^4 = x^2 * x^2
+    /// returns (true, value) if the result can be computed
+    /// returns (false, 0) if the result cannot be computed
+    fun try_simple_pow(x: FixedPoint64, y: FixedPoint64): (bool, FixedPoint64) {
+        if (fixed_point64::to_u128(y) == 0) {
+            // We solve the 0^0 indetermination by making it equal to one.
+            (true, fixed_point64::one())
+        } else if (fixed_point64::to_u128(x) == 0) {
+            (true, fixed_point64::zero())
+        } else if (fixed_point64::to_u128(y) == ONE_RAW) {
+            (true, x)
+        } else if (fixed_point64::to_u128(y) == TWO_RAW) {
+            (true, fixed_point64::mul_fp(x, x))
+        } else if (fixed_point64::to_u128(y) == TWO_POW_2_RAW) {
+            let x_squared = fixed_point64::mul_fp(x, x);
+            (true, fixed_point64::mul_fp(x_squared, x_squared))
+        } else {
+            (false, fixed_point64::zero())
+        }
     }
 }

--- a/tests/log_exp_math_tests.move
+++ b/tests/log_exp_math_tests.move
@@ -145,11 +145,26 @@ module fixed_point64::log_exp_math_tests {
         let result = log_exp_math::pow(x, y);
         assert!(fixed_point64::to_u128(result) == 8868269569660157952, 1); // (1/3)^(2/3) = 0.4807498568
 
-        let epsilon = fixed_point64::fraction(1, 1000000000);
+        let scale_up = fixed_point64::fraction(1000000001, 1000000000);
         let result = log_exp_math::pow_up(x, y);
-        assert!(fixed_point64::to_u128(result) == 8868269569660157952 + fixed_point64::to_u128(epsilon), 1);
+        assert!(fixed_point64::eq(&result, &fixed_point64::mul_fp(fixed_point64::from_u128(8868269569660157952), scale_up)), 1);
 
         let result = log_exp_math::pow_down(x, y);
-        assert!(fixed_point64::to_u128(result) == 8868269569660157952 - fixed_point64::to_u128(epsilon), 1);
+        let scale_down = fixed_point64::fraction(999999999, 1000000000);
+        assert!(fixed_point64::eq(&result, &fixed_point64::mul_fp(fixed_point64::from_u128(8868269569660157952), scale_down)), 1);
+    }
+
+    #[test]
+    fun test_pow_large_number() {
+        let max_u64_u128: u128 = 1 << 64 - 1;
+        let max_u64: u64 = (max_u64_u128 as u64);
+        let max_u64_fp = fixed_point64::encode(max_u64);
+        let a = fixed_point64::fraction(1, 8);
+        let b = fixed_point64::encode(8);
+        let result_up = log_exp_math::pow_up(log_exp_math::pow_up(max_u64_fp, a), b);
+        let result_down = log_exp_math::pow_down(log_exp_math::pow_down(max_u64_fp, a), b);
+
+        assert!(fixed_point64::gte(&result_up, &max_u64_fp), 1);
+        assert!(fixed_point64::lte(&result_down, &max_u64_fp), 1);
     }
 }

--- a/tests/log_exp_math_tests.move
+++ b/tests/log_exp_math_tests.move
@@ -159,6 +159,9 @@ module fixed_point64::log_exp_math_tests {
         let max_u64_u128: u128 = 1 << 64 - 1;
         let max_u64: u64 = (max_u64_u128 as u64);
         let max_u64_fp = fixed_point64::encode(max_u64);
+
+        // actual value of (MAX_U64 ^ (1/8)) ^ 8 is MAX_U64
+        // test pow_up and pow_down are working properly
         let a = fixed_point64::fraction(1, 8);
         let b = fixed_point64::encode(8);
         let result_up = log_exp_math::pow_up(log_exp_math::pow_up(max_u64_fp, a), b);

--- a/tests/log_exp_math_tests.move
+++ b/tests/log_exp_math_tests.move
@@ -144,5 +144,12 @@ module fixed_point64::log_exp_math_tests {
         let y = fixed_point64::fraction(2, 3);
         let result = log_exp_math::pow(x, y);
         assert!(fixed_point64::to_u128(result) == 8868269569660157952, 1); // (1/3)^(2/3) = 0.4807498568
+
+        let epsilon = fixed_point64::fraction(1, 1000000000);
+        let result = log_exp_math::pow_up(x, y);
+        assert!(fixed_point64::to_u128(result) == 8868269569660157952 + fixed_point64::to_u128(epsilon), 1);
+
+        let result = log_exp_math::pow_down(x, y);
+        assert!(fixed_point64::to_u128(result) == 8868269569660157952 - fixed_point64::to_u128(epsilon), 1);
     }
 }


### PR DESCRIPTION
Reference: https://github.com/balancer-labs/balancer-v2-monorepo/blob/master/pkg/solidity-utils/contracts/math/FixedPoint.sol#L132

This is mainly for weighted_math swap exact in/out cases. `pow` function suffers from loss of accuracy due to taylor expansion in `exp`. so we want to amend the results
- "swap exact in" wants the output to be smaller or equal to actual amount
- "swap exact out" wants the input to be greater or equal to actual amount