### PR TITLE
[fixed_point64] fix div_fp precision bug

### DIFF
--- a/tests/fixed_point64_tests.move
+++ b/tests/fixed_point64_tests.move
@@ -208,6 +208,24 @@ module fixed_point64::fixed_point64_tests {
         assert!(fixed_point64::to_u128(z) == TWO_POWER_64 * 6, 0);
         assert!(fixed_point64::decode(z) == 6, 1);
     }
+
+    #[test]
+    fun test_mul_fp_precision() {
+        let a = fixed_point64::from_u128(20724119864554512384); // 1.123456789
+        let b = fixed_point64::from_u128(55112494640199483392); // 2.987654321
+        let z = fixed_point64::mul_fp(a, b);
+        // expected: 3.35650053011
+        assert!(fixed_point64::to_u128(z) == 61916506262258222549, 0); // 3.35650053011
+    }
+
+    #[test]
+    fun test_mul_fp_precision_2() {
+        let a = fixed_point64::from_u128(409161529984780471035); // 22.180690985349592381
+        let b = fixed_point64::from_u128(1844582179910627); // 0.000099995000339357
+        let z = fixed_point64::mul_fp(a, b);
+        // expected: 0.002217958202607205
+        assert!(fixed_point64::to_u128(z) == 40914107329680144, 0); // 0.0022179582
+    }
     
     #[test]
     fun test_mul_fp_fraction() {
@@ -234,6 +252,14 @@ module fixed_point64::fixed_point64_tests {
         assert!(fixed_point64::to_u128(z) == TWO_POWER_64 * 3, 0);
         assert!(fixed_point64::decode(z) == 3, 1);
     }
+
+    #[test]
+    fun test_div_fp_precision() {
+        let a = fixed_point64::from_u128(409161529984780471035);
+        let b = fixed_point64::from_u128(1844582179910627);
+        let z = fixed_point64::div_fp(a, b);
+        assert!(fixed_point64::to_u128(z) == 4091819876955756114341262, 0); // 221818
+    }
     
     #[test]
     fun test_div_fp_fraction() {
@@ -243,9 +269,15 @@ module fixed_point64::fixed_point64_tests {
         assert!(fixed_point64::to_u128(z) == TWO_POWER_64 * 5, 0);
         assert!(fixed_point64::decode(z) == 5, 1);
     }
+
+    #[test]
+    fun test_div_fp_fraction_precision() {
+        let z = fixed_point64::fraction(7, 13); // 0.5384615384615384
+        assert!(fixed_point64::to_u128(z) == 9932862193535912408, 0); // 0.53846153846
+    }
     
     #[test]
-    #[expected_failure(abort_code = fixed_point64::fixed_point64::ERR_DIVISOR_TOO_SMALL)]
+    #[expected_failure(abort_code = fixed_point64::fixed_point64::ERR_DIVIDE_RESULT_TOO_LARGE)]
     fun test_fail_divisor_too_small_div_fp() {
         let a = fixed_point64::encode(10);
         let b = fixed_point64::from_u128(1);

--- a/tests/log_exp_math_tests.move
+++ b/tests/log_exp_math_tests.move
@@ -88,17 +88,20 @@ module fixed_point64::log_exp_math_tests {
 
     #[test]
     fun test_exp_2() {
+        // e ~= 2.7182818284590452354
         let e = fixed_point64::fraction(2718281828459045235, 1000000000000000000);
         let x = fixed_point64::encode(2);
         let result = log_exp_math::exp(1, x);
-        assert!(fixed_point64::to_u128(result) == fixed_point64::to_u128(fixed_point64::mul_fp(e, e)), 1);
+        // e does not have sufficient precision to represent result exactly accurately. For this reason we use a tolerance of 1e-15
+        let tolerance = 2;
+        assert!(fixed_point64::to_u128(result) == fixed_point64::to_u128(fixed_point64::mul_fp(e, e)) - tolerance, 1);
     }
     
     #[test]
     fun test_exp_3() {
         let x = fixed_point64::encode(3);
         let result = log_exp_math::exp(1, x);
-        assert!(fixed_point64::to_u128(result) == 370512759205086491192, 1);
+        assert!(fixed_point64::to_u128(result) == 370512759205086491193, 1);
     }
 
     #[test]
@@ -112,7 +115,8 @@ module fixed_point64::log_exp_math_tests {
     fun test_exp_1_over_3() {
         let x = fixed_point64::fraction(1, 3);
         let result = log_exp_math::exp(1, x);
-        assert!(fixed_point64::to_u128(result) == 25744505231652237576, 1); // e^(1/3) = 1.39561242462
+        // e^(1/3) = 1.395612425086
+        assert!(fixed_point64::to_u128(result) == 25744505231652237580, 1); // 1.39561242509
     }
     
     #[test]
@@ -128,7 +132,9 @@ module fixed_point64::log_exp_math_tests {
     fun test_exp_neg_1_over_3() {
         let x = fixed_point64::fraction(1, 3);
         let result = log_exp_math::exp(0, x);
-        assert!(fixed_point64::to_u128(result) == 13217669704916664320, 1); // e^(-1/3) = 0.71653131
+
+        // e^(-1/3) = 0.7165313105737893
+        assert!(fixed_point64::to_u128(result) == 13217669706954385033, 1); // 0.71653131057
     }
     
     #[test]
@@ -143,15 +149,17 @@ module fixed_point64::log_exp_math_tests {
         let x = fixed_point64::fraction(1, 3);
         let y = fixed_point64::fraction(2, 3);
         let result = log_exp_math::pow(x, y);
-        assert!(fixed_point64::to_u128(result) == 8868269569660157952, 1); // (1/3)^(2/3) = 0.4807498568
+
+        // (1/3)^(2/3) = 0.48074985676
+        assert!(fixed_point64::to_u128(result) == 8868269570899127400, 1); // 0.48074985674
 
         let scale_up = fixed_point64::fraction(1000000001, 1000000000);
         let result = log_exp_math::pow_up(x, y);
-        assert!(fixed_point64::eq(&result, &fixed_point64::mul_fp(fixed_point64::from_u128(8868269569660157952), scale_up)), 1);
+        assert!(fixed_point64::eq(&result, &fixed_point64::mul_fp(fixed_point64::from_u128(8868269570899127400), scale_up)), 1);
 
         let result = log_exp_math::pow_down(x, y);
         let scale_down = fixed_point64::fraction(999999999, 1000000000);
-        assert!(fixed_point64::eq(&result, &fixed_point64::mul_fp(fixed_point64::from_u128(8868269569660157952), scale_down)), 1);
+        assert!(fixed_point64::eq(&result, &fixed_point64::mul_fp(fixed_point64::from_u128(8868269570899127400), scale_down)), 1);
     }
 
     #[test]


### PR DESCRIPTION
It was discovered div_fp contained a precision loss bug which impacted the supported precision of division multiplication.

the exact issue was in this line:
```
let b_shift = b.v >> 32;
```
we were trying to compute 409161529984780471035 / 1844582179910627

previously, we did this by first shifting 1844582179910627 (which is 0.000099995000339357) by 32 bits, effectively dividing it by 2^32. This is normally done to help prevent over/underflows when working with u128's. The bug was that this trimmed precision bits from 0.000099995000339357 which impacted the final output.

We instead now use a u256 instead of u128. This lets us keep a lot more precision - letting us bit shift a lot more safely. This is the same approach that univ3 takes (they use a u160 for their version of fixedpoint (64.96 precision) -- then they always cast into a u256 when doing operations to allow for lots of room for bit shifts)