### PR TITLE
[fixed_point64] osec audit fixes 10/26/24

### DIFF
--- a/sources/fixed_point64.move
+++ b/sources/fixed_point64.move
@@ -29,7 +29,7 @@ module fixed_point64::fixed_point64 {
     /// When a is greater than b.
     const GREATER_THAN: u8 = 2;
 
-    const MAX_U128: u128 = 340282366920938463463374607431768211455;
+    const MAX_U128: u256 = 340282366920938463463374607431768211455;
 
     /// The resource to store `FixedPoint64`.
     struct FixedPoint64 has copy, store, drop {
@@ -95,7 +95,7 @@ module fixed_point64::fixed_point64 {
         FixedPoint64{ v: 0 }
     }
 
-    /// Multiply a `FixedPoint64` by a `u64`, returning a `FixedPoint64`
+    /// Multiply a `FixedPoint64` by a `u128`, returning a `FixedPoint64`
     public fun mul(fp: FixedPoint64, y: u128): FixedPoint64 {
         // vm would direct abort when overflow occured
         let v = fp.v * y;
@@ -103,7 +103,7 @@ module fixed_point64::fixed_point64 {
         FixedPoint64{ v }
     }
 
-    /// Divide a `FixedPoint64` by a `u64`, returning a `FixedPoint64`.
+    /// Divide a `FixedPoint64` by a `u128`, returning a `FixedPoint64`.
     public fun div(fp: FixedPoint64, y: u128): FixedPoint64 {
         assert!(y != 0, ERR_DIVIDE_BY_ZERO);
 
@@ -111,18 +111,18 @@ module fixed_point64::fixed_point64 {
         FixedPoint64{ v }
     }
 
-    /// Add a `FixedPoint64` and a `u64`, returning a `FixedPoint64`
+    /// Add a `FixedPoint64` and a `u128`, returning a `FixedPoint64`
     public fun add(fp: FixedPoint64, y: u128): FixedPoint64 {
         // vm would direct abort when overflow occured
-        let v = fp.v + (y << 64);
+        let v = ((fp.v as u256) + ((y as u256) << 64) as u128);
 
         FixedPoint64{ v }
     }
 
-    /// Subtract `FixedPoint64` by a `u64`, returning a `FixedPoint64`
+    /// Subtract `FixedPoint64` by a `u128`, returning a `FixedPoint64`
     public fun sub(fp: FixedPoint64, y: u128): FixedPoint64 {
         // vm would direct abort when underflow occured
-        let v = fp.v - (y << 64);
+        let v = ((fp.v as u256) - ((y as u256) << 64) as u128);
 
         FixedPoint64{ v }
     }
@@ -163,7 +163,7 @@ module fixed_point64::fixed_point64 {
         let scaled_result = result_u256 >> 64;
 
         // Ensure the result fits into u128
-        assert!(scaled_result <= (MAX_U128 as u256), ERR_MULTIPLY_RESULT_TOO_LARGE);
+        assert!(scaled_result <= MAX_U128, ERR_MULTIPLY_RESULT_TOO_LARGE);
 
         let v = (scaled_result as u128);
 
@@ -189,7 +189,7 @@ module fixed_point64::fixed_point64 {
         let result_u256 = scaled_a / b_u256;
 
         // Ensure the result fits into u128
-        assert!(result_u256 <= (MAX_U128 as u256), ERR_DIVIDE_RESULT_TOO_LARGE);
+        assert!(result_u256 <= MAX_U128, ERR_DIVIDE_RESULT_TOO_LARGE);
 
         let v = (result_u256 as u128);
 
@@ -200,8 +200,8 @@ module fixed_point64::fixed_point64 {
     public fun fraction(numerator: u128, denominator: u128): FixedPoint64 {
         assert!(denominator != 0, ERR_DIVIDE_BY_ZERO);
 
-        let r = numerator << 64;
-        let v = r / denominator;
+        let r = (numerator as u256) << 64;
+        let v = (r / (denominator as u256) as u128);
 
         FixedPoint64{ v }
     }

--- a/tests/fixed_point64_tests.move
+++ b/tests/fixed_point64_tests.move
@@ -3,6 +3,7 @@ module fixed_point64::fixed_point64_tests {
     use fixed_point64::fixed_point64;
 
     const MAX_U64: u64 = 18446744073709551615; // 2^64 - 1
+    const MAX_U128: u128 = 340282366920938463463374607431768211455;
     const TWO_POWER_64: u128 = 18446744073709551616;
 
     #[test]
@@ -100,10 +101,24 @@ module fixed_point64::fixed_point64_tests {
     }
 
     #[test]
+    #[expected_failure]
+    fun test_fail_mul_large() {
+        let a = fixed_point64::encode(5);
+        fixed_point64::mul(a, MAX_U128);
+    }
+
+    #[test]
     fun test_fraction() {
         let a = fixed_point64::fraction(8, 2);
         assert!(fixed_point64::to_u128(a) == TWO_POWER_64 * 4, 0);
         assert!(fixed_point64::decode(a) == 4, 1);
+    }
+
+    #[test]
+    fun test_fraction_large() {
+        let a = fixed_point64::fraction(MAX_U128, MAX_U128 - 1);
+        assert!(fixed_point64::to_u128(a) == TWO_POWER_64, 0);
+        assert!(fixed_point64::decode(a) == 1, 1);
     }
 
     #[test]
@@ -147,8 +162,8 @@ module fixed_point64::fixed_point64_tests {
     #[test]
     #[expected_failure]
     fun test_fail_overflow_add() {
-        let a = fixed_point64::encode(MAX_U64);
-        fixed_point64::add(a, (MAX_U64 as u128));
+        let a = fixed_point64::encode(1);
+        fixed_point64::add(a, MAX_U128 - 100);
     }
 
     #[test]
@@ -157,6 +172,13 @@ module fixed_point64::fixed_point64_tests {
         let z = fixed_point64::sub(a, 2);
         assert!(fixed_point64::to_u128(z) == TWO_POWER_64, 0);
         assert!(fixed_point64::decode(z) == 1, 1);
+    }
+
+    #[test]
+    #[expected_failure]
+    fun test_fail_underflow_sub_large() {
+        let a = fixed_point64::encode(MAX_U64);
+        fixed_point64::sub(a, MAX_U128 - 100);
     }
     
     #[test]


### PR DESCRIPTION
1. In move, shift operations don’t abort on overflow. If inputs exceed u64::MAX, the functions return incorrect results, due to truncation of the lowest bits during shifting.
2. In fraction, the intermediate multiplication could upscale to u256, with the final result downscaled after division to avoid unnecessary aborts.
